### PR TITLE
Fix for Timer

### DIFF
--- a/src/Microwave.Core/Boundary/Timer.cs
+++ b/src/Microwave.Core/Boundary/Timer.cs
@@ -43,7 +43,7 @@ namespace Microwave.Core.Boundary
         {
             // One tick has passed
             // Do what I should
-            TimeRemaining -= 1000; // SHOULD BE 1
+            TimeRemaining--;
             TimerTick?.Invoke(this, EventArgs.Empty);
 
             if (TimeRemaining <= 0)

--- a/tests/Microwave.Test.Unit/TimerTest.cs
+++ b/tests/Microwave.Test.Unit/TimerTest.cs
@@ -21,7 +21,7 @@ namespace Microwave.Test.Unit
             ManualResetEvent pause = new ManualResetEvent(false);
 
             uut.TimerTick += (sender, args) => pause.Set();
-            uut.Start(2000);
+            uut.Start(2);
 
             // wait for a tick, but no longer
             Assert.That(pause.WaitOne(1100));
@@ -35,7 +35,7 @@ namespace Microwave.Test.Unit
             ManualResetEvent pause = new ManualResetEvent(false);
 
             uut.TimerTick += (sender, args) => pause.Set();
-            uut.Start(2000);
+            uut.Start(2);
 
             // wait shorter than a tick, shouldn't come
             Assert.That(!pause.WaitOne(900));
@@ -49,7 +49,7 @@ namespace Microwave.Test.Unit
             ManualResetEvent pause = new ManualResetEvent(false);
 
             uut.Expired += (sender, args) => pause.Set();
-            uut.Start(2000);
+            uut.Start(2);
 
             // wait for expiration, but not much longer, should come
             Assert.That(pause.WaitOne(2100));
@@ -63,7 +63,7 @@ namespace Microwave.Test.Unit
             ManualResetEvent pause = new ManualResetEvent(false);
 
             uut.Expired += (sender, args) => pause.Set();
-            uut.Start(2000);
+            uut.Start(2);
 
             // wait shorter than expiration, shouldn't come
             Assert.That(!pause.WaitOne(1900));
@@ -80,7 +80,7 @@ namespace Microwave.Test.Unit
             uut.Expired += (sender, args) => pause.Set();
             uut.TimerTick += (sender, args) => notifications++;
 
-            uut.Start(2000);
+            uut.Start(2);
 
             // wait longer than expiration
             Assert.That(pause.WaitOne(2100));
@@ -88,6 +88,5 @@ namespace Microwave.Test.Unit
 
             Assert.That(notifications, Is.EqualTo(2));
         }
-
     }
 }


### PR DESCRIPTION
* Updated timer to decrement `TimeRemaining `on `System.Timer.Elapsed` (each second)
* Updated unit tests to use seconds instead if milliseconds

All tests are passed.